### PR TITLE
add setting for default new file line endings

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -11,12 +11,12 @@ const LineEndingRegExp = /\r\n|\n/g
 let disposables = null
 
 export let config = {
-  defaultNewFileLineEnding: {
+  defaultLineEnding: {
     title: 'Default line ending for new files',
     type: 'string',
     'default': 'OS Default',
     enum: ['OS Default', 'LF', 'CRLF'],
-    descrition: 'Default line ending for new documents'
+    description: 'Default line ending for new documents'
   }
 }
 
@@ -64,9 +64,9 @@ export function consumeStatusBar (statusBar) {
   function updateTile (buffer) {
     let lineEndings = getLineEndings(buffer)
     if (lineEndings.size === 0) {
-      let defaultNewFileLineEnding = getDefaultNewFileLineEnding()
-      buffer.setPreferredLineEnding(defaultNewFileLineEnding)
-      lineEndings = new Set().add(defaultNewFileLineEnding)
+      let defaultLineEnding = getDefaultLineEnding()
+      buffer.setPreferredLineEnding(defaultLineEnding)
+      lineEndings = new Set().add(defaultLineEnding)
     }
     statusBarItem.setLineEndings(lineEndings)
   }
@@ -113,9 +113,9 @@ export function consumeStatusBar (statusBar) {
   disposables.add(new Disposable(() => tile.destroy()))
 }
 
-function getDefaultNewFileLineEnding () {
-  let defaultNewFileLineEnding = atom.config.get('line-ending-selector.defaultNewFileLineEnding')
-  switch (defaultNewFileLineEnding) {
+function getDefaultLineEnding () {
+  let defaultLineEnding = atom.config.get('line-ending-selector.defaultLineEnding')
+  switch (defaultLineEnding) {
     case 'LF':
       return '\n'
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -10,6 +10,16 @@ const LineEndingRegExp = /\r\n|\n/g
 
 let disposables = null
 
+export let config = {
+  defaultNewFileLineEnding: {
+    title: 'Default line ending for new files',
+    type: 'string',
+    'default': 'OS Default',
+    enum: ['OS Default', 'LF', 'CRLF'],
+    descrition: 'Default line ending for new documents'
+  }
+};
+
 export function activate () {
   disposables = new CompositeDisposable()
 
@@ -54,9 +64,9 @@ export function consumeStatusBar (statusBar) {
   function updateTile (buffer) {
     let lineEndings = getLineEndings(buffer)
     if (lineEndings.size === 0) {
-      let platformLineEnding = getPlatformLineEnding()
-      buffer.setPreferredLineEnding(platformLineEnding)
-      lineEndings = new Set().add(platformLineEnding)
+      let defaultNewFileLineEnding = getDefaultNewFileLineEnding()
+      buffer.setPreferredLineEnding(defaultNewFileLineEnding)
+      lineEndings = new Set().add(defaultNewFileLineEnding)
     }
     statusBarItem.setLineEndings(lineEndings)
   }
@@ -103,11 +113,18 @@ export function consumeStatusBar (statusBar) {
   disposables.add(new Disposable(() => tile.destroy()))
 }
 
-function getPlatformLineEnding () {
-  if (helpers.getProcessPlatform() === 'win32') {
-    return '\r\n'
-  } else {
-    return '\n'
+function getDefaultNewFileLineEnding () {
+  let defaultNewFileLineEnding = atom.config.get('line-ending-selector.defaultNewFileLineEnding');
+  switch (defaultNewFileLineEnding) {
+    case 'LF':
+      return '\n';
+
+    case 'CRLF':
+      return '\r\n';
+
+    case 'OS Default':
+    default:
+      return (helpers.getProcessPlatform() === 'win32') ? '\r\n' : '\n';
   }
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,7 +16,7 @@ export let config = {
     type: 'string',
     'default': 'OS Default',
     enum: ['OS Default', 'LF', 'CRLF'],
-    description: 'Default line ending for new documents'
+    description: 'Default line ending for new files'
   }
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,7 +18,7 @@ export let config = {
     enum: ['OS Default', 'LF', 'CRLF'],
     descrition: 'Default line ending for new documents'
   }
-};
+}
 
 export function activate () {
   disposables = new CompositeDisposable()
@@ -114,17 +114,17 @@ export function consumeStatusBar (statusBar) {
 }
 
 function getDefaultNewFileLineEnding () {
-  let defaultNewFileLineEnding = atom.config.get('line-ending-selector.defaultNewFileLineEnding');
+  let defaultNewFileLineEnding = atom.config.get('line-ending-selector.defaultNewFileLineEnding')
   switch (defaultNewFileLineEnding) {
     case 'LF':
-      return '\n';
+      return '\n'
 
     case 'CRLF':
-      return '\r\n';
+      return '\r\n'
 
     case 'OS Default':
     default:
-      return (helpers.getProcessPlatform() === 'win32') ? '\r\n' : '\n';
+      return (helpers.getProcessPlatform() === 'win32') ? '\r\n' : '\n'
   }
 }
 

--- a/spec/line-ending-selector-spec.js
+++ b/spec/line-ending-selector-spec.js
@@ -56,10 +56,7 @@ describe('line ending selector', () => {
   })
 
   describe('Settings: \'Default line ending for new files\'', () => {
-
-
     describe('when empty file is opened with \'OS Default\' setting', () => {
-
       beforeEach(() => atom.config.set('line-ending-selector.defaultLineEnding', 'OS Default'))
 
       it('determines new file line ending on Windows platform', () => {
@@ -86,7 +83,6 @@ describe('line ending selector', () => {
     })
 
     describe('when empty file is opened with \'CRLF\' setting', () => {
-
       beforeEach(() => atom.config.set('line-ending-selector.defaultLineEnding', 'CRLF'))
 
       it('determines new file line ending on Windows platform', () => {
@@ -113,7 +109,6 @@ describe('line ending selector', () => {
     })
 
     describe('when empty file is opened with \'LF\' setting', () => {
-
       beforeEach(() => atom.config.set('line-ending-selector.defaultLineEnding', 'LF'))
 
       it('determines new file line ending on Windows platform', () => {
@@ -138,9 +133,7 @@ describe('line ending selector', () => {
         })
       })
     })
-
   })
-
 
   describe('Status bar tile', () => {
     describe('when empty file is opened', () => {

--- a/spec/line-ending-selector-spec.js
+++ b/spec/line-ending-selector-spec.js
@@ -55,6 +55,93 @@ describe('line ending selector', () => {
     })
   })
 
+  describe('Settings: \'Default line ending for new files\'', () => {
+
+
+    describe('when empty file is opened with \'OS Default\' setting', () => {
+
+      beforeEach(() => atom.config.set('line-ending-selector.defaultLineEnding', 'OS Default'))
+
+      it('determines new file line ending on Windows platform', () => {
+        spyOn(helpers, 'getProcessPlatform').andReturn('win32')
+
+        waitsForPromise(() => {
+          return atom.workspace.open('').then((editor) => {
+            expect(lineEndingTile.textContent).toBe('CRLF')
+            expect(editor.getBuffer().getPreferredLineEnding()).toBe('\r\n')
+          })
+        })
+      })
+
+      it('determines new file line ending on *nix platforms', () => {
+        spyOn(helpers, 'getProcessPlatform').andReturn('*nix')
+
+        waitsForPromise(() => {
+          return atom.workspace.open('').then((editor) => {
+            expect(lineEndingTile.textContent).toBe('LF')
+            expect(editor.getBuffer().getPreferredLineEnding()).toBe('\n')
+          })
+        })
+      })
+    })
+
+    describe('when empty file is opened with \'CRLF\' setting', () => {
+
+      beforeEach(() => atom.config.set('line-ending-selector.defaultLineEnding', 'CRLF'))
+
+      it('determines new file line ending on Windows platform', () => {
+        spyOn(helpers, 'getProcessPlatform').andReturn('win32')
+
+        waitsForPromise(() => {
+          return atom.workspace.open('').then((editor) => {
+            expect(lineEndingTile.textContent).toBe('CRLF')
+            expect(editor.getBuffer().getPreferredLineEnding()).toBe('\r\n')
+          })
+        })
+      })
+
+      it('determines new file line ending on *nix platforms', () => {
+        spyOn(helpers, 'getProcessPlatform').andReturn('*nix')
+
+        waitsForPromise(() => {
+          return atom.workspace.open('').then((editor) => {
+            expect(lineEndingTile.textContent).toBe('CRLF')
+            expect(editor.getBuffer().getPreferredLineEnding()).toBe('\r\n')
+          })
+        })
+      })
+    })
+
+    describe('when empty file is opened with \'LF\' setting', () => {
+
+      beforeEach(() => atom.config.set('line-ending-selector.defaultLineEnding', 'LF'))
+
+      it('determines new file line ending on Windows platform', () => {
+        spyOn(helpers, 'getProcessPlatform').andReturn('win32')
+
+        waitsForPromise(() => {
+          return atom.workspace.open('').then((editor) => {
+            expect(lineEndingTile.textContent).toBe('LF')
+            expect(editor.getBuffer().getPreferredLineEnding()).toBe('\n')
+          })
+        })
+      })
+
+      it('determines new file line ending on *nix platforms', () => {
+        spyOn(helpers, 'getProcessPlatform').andReturn('*nix')
+
+        waitsForPromise(() => {
+          return atom.workspace.open('').then((editor) => {
+            expect(lineEndingTile.textContent).toBe('LF')
+            expect(editor.getBuffer().getPreferredLineEnding()).toBe('\n')
+          })
+        })
+      })
+    })
+
+  })
+
+
   describe('Status bar tile', () => {
     describe('when empty file is opened', () => {
       it('determines line ending from system platform', () => {


### PR DESCRIPTION
This PR resolves #5 by enabling setting the default line endings for **new files** as shown below.

| Setting | Effect |
| --- | --- |
| **OS Default** | Use the OS to determine which line ending to use for new files |
| **LF** | Use `'\n'` for new files |
| **CRLF** | Use `'\r\n'` for new files |

This is purely for **new files** and does not affect changes made after the new file has been created and contains text.
