### PR TITLE
Remove dependency on underscore-plus

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,5 @@
 'use babel'
 
-import _ from 'underscore-plus'
 import {CompositeDisposable, Disposable} from 'atom'
 import LineEndingListView from './line-ending-list-view'
 import StatusBarItem from './status-bar-item'
@@ -61,7 +60,9 @@ export function consumeStatusBar (statusBar) {
     statusBarItem.setLineEndings(lineEndings)
   }
 
-  let debouncedUpdateTile = _.debounce(updateTile, 0)
+  let debouncedUpdateTile = (buffer) => {
+    setTimeout(updateTile.bind(null, buffer), 0);
+  }
 
   disposables.add(atom.workspace.observeActivePaneItem((item) => {
     if (currentBufferDisposable) currentBufferDisposable.dispose()

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "atom": "^1.0.0"
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.0.0",
-    "underscore-plus": "^1.6.6"
+    "atom-space-pen-views": "^2.0.0"
   },
   "consumedServices": {
     "status-bar": {


### PR DESCRIPTION
`underscore-plus` appears to be included only for `debounce`. The one use of `debounce` passes a value of 0, so I'm not sure that does anything.

This PR replaces it with a call to `setTimeout()`, which I think may work just as well, while eliminating the require of `underscore-plus` from the critical path.

It's hard to tell what the overall effect on load time is because my fork is `apm link`'d in, which I think puts it at a serious performance disadvantage as compared to the built-in version of the package that is loaded from the `app.asar` file, which is much faster.

Unfortunately, `LineEndingListView` is still loaded eagerly, which means `atom-space-pen-views` is, as well. Since [Atom core no longer depends on `space-pen` itself](https://github.com/atom/atom/commit/d51c12063ba0ecb692774aa10b00784fd5a232cf#diff-b9cfc7f2cdf78a7f4b91a753d10865a2), it would be great to either eliminate the dependency in this package altogether, or at least lazy-load it.
