### PR TITLE
Display CR line endings

### DIFF
--- a/lib/status-bar-item.js
+++ b/lib/status-bar-item.js
@@ -28,6 +28,8 @@ function lineEndingName (lineEndings) {
     return 'LF'
   } else if (lineEndings.has('\r\n')) {
     return 'CRLF'
+  } else if (lineEndings.has('\r')) {
+    return 'CR'
   } else {
     return ''
   }

--- a/spec/fixtures/old-endings.md
+++ b/spec/fixtures/old-endings.md
@@ -1,0 +1,1 @@
+HelloGoodbyeOld style

--- a/spec/line-ending-selector-spec.js
+++ b/spec/line-ending-selector-spec.js
@@ -100,6 +100,17 @@ describe('line ending selector', () => {
       })
     })
 
+    describe('when a file is opened that contains all old style line endings', () => {
+      it('displays "CR" line endings', () => {
+        waitsForPromise(() => {
+          return atom.workspace.open('old-endings.md').then((editor) => {
+            expect(lineEndingTile.textContent).toBe('CR')
+            expect(editor.getBuffer().getPreferredLineEnding()).toBe(null)
+          })
+        })
+      })
+    })
+
     describe('clicking the tile', () => {
       beforeEach(() => {
         waitsForPromise(() => {


### PR DESCRIPTION
Display 'CR' in the status bar when a file is detected to have those line endings. Does not add the ability to convert to that style.

Closes #4.
