### PR TITLE
Allow old-style EOL terminators to be modified

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,7 +5,7 @@ import {CompositeDisposable, Disposable} from 'atom'
 import StatusBarItem from './status-bar-item'
 import helpers from './helpers'
 
-const LineEndingRegExp = /\r\n|\n/g
+const LineEndingRegExp = /\r\n|\n|\r/g
 
 let disposables = null
 let modalPanel = null


### PR DESCRIPTION
It's currently impossible to convert a file using old-style line-endings (CR) to LF or CRLF.

Note there's still a bug where the selection menu's label doesn't revert back to "CR" if the user undoes the conversion. I haven't been able to track down why this happens, though I suspect the catalyst lies within a different repository.
