### PR TITLE
Add class to line ending modal

### DIFF
--- a/lib/line-ending-list-view.js
+++ b/lib/line-ending-list-view.js
@@ -6,6 +6,7 @@ export default class LineEndingListView extends SelectListView {
   initialize (callback) {
     this.callback = callback
     super.initialize()
+    this.addClass('line-ending')
     this.setItems([{name: 'LF', value: '\n'}, {name: 'CRLF', value: '\r\n'}])
   }
 


### PR DESCRIPTION
Add `line-ending` to class list of the line ending list view, to distinguish it from other modals for styling purposes.
