### PR TITLE
Use target.closest('atom-text-editor') to access the editor element

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -38,11 +38,13 @@ export function activate () {
     },
 
     'line-ending-selector:convert-to-LF': (event) => {
-      setLineEnding(event.target.getModel(), '\n')
+      const editorElement = event.target.closest('atom-text-editor')
+      setLineEnding(editorElement.getModel(), '\n')
     },
 
     'line-ending-selector:convert-to-CRLF': (event) => {
-      setLineEnding(event.target.getModel(), '\r\n')
+      const editorElement = event.target.closest('atom-text-editor')
+      setLineEnding(editorElement.getModel(), '\r\n')
     }
   }))
 }

--- a/spec/line-ending-selector-spec.js
+++ b/spec/line-ending-selector-spec.js
@@ -45,20 +45,23 @@ describe('line ending selector', () => {
         return atom.workspace.open('mixed-endings.md').then((e) => {
           editor = e
           editorElement = atom.views.getView(editor)
+          jasmine.attachToDOM(editorElement)
         })
       })
     })
 
     describe('When "line-ending-selector:convert-to-LF" is run', () => {
       it('converts the file to LF line endings', () => {
-        atom.commands.dispatch(editorElement, 'line-ending-selector:convert-to-LF')
+        editorElement.focus()
+        atom.commands.dispatch(document.activeElement, 'line-ending-selector:convert-to-LF')
         expect(editor.getText()).toBe('Hello\nGoodbye\nMixed\n')
       })
     })
 
     describe('When "line-ending-selector:convert-to-LF" is run', () => {
       it('converts the file to CRLF line endings', () => {
-        atom.commands.dispatch(editorElement, 'line-ending-selector:convert-to-CRLF')
+        editorElement.focus()
+        atom.commands.dispatch(document.activeElement, 'line-ending-selector:convert-to-CRLF')
         expect(editor.getText()).toBe('Hello\r\nGoodbye\r\nMixed\r\n')
       })
     })


### PR DESCRIPTION
Refs: https://github.com/atom/atom/issues/13189

With the removal of the shadow DOM boundary from `atom-text-editor` elements, `event.target` could sometimes report the hidden input inside the editor instead of the element itself. This caused the `line-ending-selector:convert-to-CRLF` and `line-ending-selector:convert-to-LF` commands to stop working because they were relying on `event.target` being an instance of `TextEditorElement`.

This pull request fixes it by using `event.target.closest('atom-text-editor')` instead, and by making tests more realistic to ensure that similar regressions can be caught in the future.

/cc: @atom/core 