### PR TITLE
add a tooltip to the status bar item

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -66,6 +66,7 @@ export function deactivate () {
 export function consumeStatusBar (statusBar) {
   let statusBarItem = new StatusBarItem()
   let currentBufferDisposable = null
+  let tooltipDisposable = null
 
   function updateTile (buffer) {
     let lineEndings = getLineEndings(buffer)
@@ -102,6 +103,14 @@ export function consumeStatusBar (statusBar) {
       statusBarItem.setLineEndings(new Set())
       currentBufferDisposable = null
     }
+
+    if (tooltipDisposable) {
+      disposables.remove(tooltipDisposable)
+      tooltipDisposable.dispose()
+    }
+    tooltipDisposable = atom.tooltips.add(statusBarItem.element,
+      {title: `File uses ${statusBarItem.description()} line endings`})
+    disposables.add(tooltipDisposable)
   }))
 
   disposables.add(new Disposable(() => {

--- a/lib/status-bar-item.js
+++ b/lib/status-bar-item.js
@@ -16,6 +16,10 @@ export default class StatusBarItem {
     return this.lineEndings.has(lineEnding)
   }
 
+  description () {
+    return lineEndingDescription(this.lineEndings)
+  }
+
   onClick (callback) {
     this.element.addEventListener('click', callback)
   }
@@ -33,4 +37,15 @@ function lineEndingName (lineEndings) {
   } else {
     return ''
   }
+}
+
+function lineEndingDescription (lineEndings) {
+  const convert = {
+    Mixed: 'mixed',
+    LF: 'LF (Unix)',
+    CRLF: 'CRLF (Windows)',
+    CR: 'CR (old Macintosh)'
+  }
+
+  return convert[lineEndingName(lineEndings) || 'unknown']
 }

--- a/lib/status-bar-item.js
+++ b/lib/status-bar-item.js
@@ -44,7 +44,7 @@ function lineEndingDescription (lineEndings) {
     Mixed: 'mixed',
     LF: 'LF (Unix)',
     CRLF: 'CRLF (Windows)',
-    CR: 'CR (old Macintosh)'
+    CR: 'CR (Classic MacOS)'
   }
 
   return convert[lineEndingName(lineEndings) || 'unknown']


### PR DESCRIPTION
### Requirements

### Description of the Change

This PR adds a tooltip to the status bar item:

![image](https://cloud.githubusercontent.com/assets/1776/24786529/18e1f93c-1b17-11e7-9d2e-08df8a7f5da4.png)

### Alternate Designs

No alternate designs were considered.

### Benefits

Now even inexpert users should be able to understand what "LF" in the status bar means.

### Possible Drawbacks

More code.

### Applicable Issues

Should fix https://github.com/atom/line-ending-selector/issues/14

Inspired by https://github.com/atom/encoding-selector/pull/28 and https://github.com/atom/encoding-selector/pull/45