### PR TITLE
Update package in preparation for native text buffer

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -145,7 +145,7 @@ function getLineEndings (buffer) {
   if (typeof buffer.search === 'function') {
     return Promise.all([
       buffer.search(LFRegExp),
-      buffer.search(CRLFRegExp),
+      buffer.search(CRLFRegExp)
     ]).then(([hasLF, hasCRLF]) => {
       const result = new Set()
       if (hasLF) result.add('\n')

--- a/lib/main.js
+++ b/lib/main.js
@@ -6,7 +6,9 @@ import SelectListView from 'atom-select-list'
 import StatusBarItem from './status-bar-item'
 import helpers from './helpers'
 
-const LineEndingRegExp = /\r\n|\n|\r/g
+const LineEndingRegExp = /\r\n|\n/g
+const LFRegExp = /(^|[^\r])\n/g
+const CRLFRegExp = /\r\n/g
 
 let disposables = null
 let modalPanel = null
@@ -68,17 +70,16 @@ export function consumeStatusBar (statusBar) {
   let currentBufferDisposable = null
   let tooltipDisposable = null
 
-  function updateTile (buffer) {
-    let lineEndings = getLineEndings(buffer)
-    if (lineEndings.size === 0) {
-      let defaultLineEnding = getDefaultLineEnding()
-      buffer.setPreferredLineEnding(defaultLineEnding)
-      lineEndings = new Set().add(defaultLineEnding)
-    }
-    statusBarItem.setLineEndings(lineEndings)
-  }
-
-  let debouncedUpdateTile = _.debounce(updateTile, 0)
+  const updateTile = _.debounce((buffer) => {
+    getLineEndings(buffer).then((lineEndings) => {
+      if (lineEndings.size === 0) {
+        let defaultLineEnding = getDefaultLineEnding()
+        buffer.setPreferredLineEnding(defaultLineEnding)
+        lineEndings = new Set().add(defaultLineEnding)
+      }
+      statusBarItem.setLineEndings(lineEndings)
+    })
+  }, 0)
 
   disposables.add(atom.workspace.observeActivePaneItem((item) => {
     if (currentBufferDisposable) currentBufferDisposable.dispose()
@@ -89,14 +90,14 @@ export function consumeStatusBar (statusBar) {
       currentBufferDisposable = buffer.onDidChange(({oldText, newText}) => {
         if (!statusBarItem.hasLineEnding('\n')) {
           if (newText.indexOf('\n') >= 0) {
-            debouncedUpdateTile(buffer)
+            updateTile(buffer)
           }
         } else if (!statusBarItem.hasLineEnding('\r\n')) {
           if (newText.indexOf('\r\n') >= 0) {
-            debouncedUpdateTile(buffer)
+            updateTile(buffer)
           }
-        } else if (LineEndingRegExp.test(oldText)) {
-          debouncedUpdateTile(buffer)
+        } else if (oldText.indexOf('\n')) {
+          updateTile(buffer)
         }
       })
     } else {
@@ -124,7 +125,7 @@ export function consumeStatusBar (statusBar) {
     )
   })
 
-  let tile = statusBar.addRightTile({item: statusBarItem.element, priority: 200})
+  let tile = statusBar.addRightTile({item: statusBarItem, priority: 200})
   disposables.add(new Disposable(() => tile.destroy()))
 }
 
@@ -141,11 +142,25 @@ function getDefaultLineEnding () {
 }
 
 function getLineEndings (buffer) {
-  let result = new Set()
-  for (let i = 0; i < buffer.getLineCount() - 1; i++) {
-    result.add(buffer.lineEndingForRow(i))
+  if (typeof buffer.search === 'function') {
+    return Promise.all([
+      buffer.search(LFRegExp),
+      buffer.search(CRLFRegExp),
+    ]).then(([hasLF, hasCRLF]) => {
+      const result = new Set()
+      if (hasLF) result.add('\n')
+      if (hasCRLF) result.add('\r\n')
+      return result
+    })
+  } else {
+    return new Promise((resolve) => {
+      const result = new Set()
+      for (let i = 0; i < buffer.getLineCount() - 1; i++) {
+        result.add(buffer.lineEndingForRow(i))
+      }
+      resolve(result)
+    })
   }
-  return result
 }
 
 function setLineEnding (item, lineEnding) {

--- a/lib/status-bar-item.js
+++ b/lib/status-bar-item.js
@@ -1,15 +1,22 @@
-'use babel'
+const {Emitter} = require('atom')
 
-export default class StatusBarItem {
+module.exports =
+class StatusBarItem {
   constructor () {
     this.element = document.createElement('a')
     this.element.className = 'line-ending-tile inline-block'
+    this.emitter = new Emitter()
     this.setLineEndings(new Set())
   }
 
   setLineEndings (lineEndings) {
     this.lineEndings = lineEndings
     this.element.textContent = lineEndingName(lineEndings)
+    this.emitter.emit('did-change')
+  }
+
+  onDidChange (callback) {
+    return this.emitter.on('did-change', callback)
   }
 
   hasLineEnding (lineEnding) {
@@ -32,8 +39,6 @@ function lineEndingName (lineEndings) {
     return 'LF'
   } else if (lineEndings.has('\r\n')) {
     return 'CRLF'
-  } else if (lineEndings.has('\r')) {
-    return 'CR'
   } else {
     return ''
   }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
       "runs",
       "spyOn",
       "waits",
+      "waitsFor",
       "waitsForPromise"
     ]
   }

--- a/spec/fixtures/old-endings.md
+++ b/spec/fixtures/old-endings.md
@@ -1,1 +1,0 @@
-HelloGoodbyeOld style


### PR DESCRIPTION
As part of the performance work in https://github.com/atom/atom/pull/14435, we have decided to drop support for treating lone `\r`characters as line endings. Handling these would have become a bit more complicated with our new text buffer representation, and given how rarely this feature is used, we didn't think it was worth it.

It's possible we'll re-add support for them in the future if people care enough about it that it becomes more important than all of the other performance improvements that we're trying to get done.

In addition, this PR optimizes the detection of which line endings are in use in a given file by taking advantage of the TextBuffer's new async regex search feature. Because we support mixed line endings, detecting a file's line endings requires scanning the entire file. Previously, for a 2MB file, this could take upwards of 50ms. Now it's essentially instantaneous.