### PR TITLE
Restore ability to display line ending for pending text editor panes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -81,7 +81,7 @@ export function consumeStatusBar (statusBar) {
     })
   }, 0)
 
-  disposables.add(atom.workspace.observeActivePaneItem((item) => {
+  const observeActiveItem = function (item) {
     if (currentBufferDisposable) currentBufferDisposable.dispose()
 
     if (item && item.getBuffer) {
@@ -112,7 +112,14 @@ export function consumeStatusBar (statusBar) {
     tooltipDisposable = atom.tooltips.add(statusBarItem.element,
       {title: `File uses ${statusBarItem.description()} line endings`})
     disposables.add(tooltipDisposable)
-  }))
+  }
+
+  // TODO[v1.19]: Remove conditional once atom.workspace.observeActiveTextEditor ships in Atom v1.19
+  if (atom.workspace.observeActiveTextEditor) {
+    disposables.add(atom.workspace.observeActiveTextEditor(observeActiveItem))
+  } else {
+    disposables.add(atom.workspace.observeActivePaneItem(observeActiveItem))
+  }
 
   disposables.add(new Disposable(() => {
     if (currentBufferDisposable) currentBufferDisposable.dispose()

--- a/lib/main.js
+++ b/lib/main.js
@@ -24,7 +24,12 @@ export function activate () {
           items: [{name: 'LF', value: '\n'}, {name: 'CRLF', value: '\r\n'}],
           filterKeyForItem: (lineEnding) => lineEnding.name,
           didConfirmSelection: (lineEnding) => {
-            setLineEnding(atom.workspace.getActivePaneItem(), lineEnding.value)
+            // TODO[v1.19]: Remove conditional once atom.workspace.getActiveTextEditor ships in Atom v1.19
+            if (atom.workspace.getActiveTextEditor) {
+              setLineEnding(atom.workspace.getActiveTextEditor(), lineEnding.value)
+            } else {
+              setLineEnding(atom.workspace.getActivePaneItem(), lineEnding.value)
+            }
             modalPanel.hide()
           },
           didCancelSelection: () => {
@@ -126,8 +131,17 @@ export function consumeStatusBar (statusBar) {
   }))
 
   statusBarItem.onClick(() => {
+    let editor
+
+    // TODO[v1.19]: Remove conditional once atom.workspace.getActiveTextEditor ships in Atom v1.19
+    if (atom.workspace.getActiveTextEditor) {
+      editor = atom.workspace.getActiveTextEditor()
+    } else {
+      editor = atom.workspace.getActivePaneItem()
+    }
+
     atom.commands.dispatch(
-      atom.views.getView(atom.workspace.getActivePaneItem()),
+      atom.views.getView(editor),
       'line-ending-selector:show'
     )
   })


### PR DESCRIPTION
### Description of the Change

As one part of resolving https://github.com/atom/status-bar/issues/194, this pull request updates this package to take advantage of the new `Workspace::observeActiveTextEditor(callback)` API being introduced in https://github.com/atom/atom/pull/14695.

### Alternate Designs

See https://github.com/atom/atom/pull/14695

### Benefits

The package will regain the ability to display the line ending for pending text editor panes.

### Possible Drawbacks

See https://github.com/atom/atom/pull/14695

### Applicable Issues

- https://github.com/atom/atom/issues/14648
- https://github.com/atom/status-bar/issues/194

### Demo

#### Before

![line-ending-selector-before](https://cloud.githubusercontent.com/assets/2988/26733660/80090940-4789-11e7-92ba-a85bdfce774a.gif)

#### After

![line-ending-selector-after](https://cloud.githubusercontent.com/assets/2988/26733659/8005e3f0-4789-11e7-9d93-bc5d58b116cc.gif)
