### PR TITLE
✅ Add test for bug fixed in 2ff4ee3f83

### DIFF
--- a/spec/line-ending-selector-spec.js
+++ b/spec/line-ending-selector-spec.js
@@ -197,7 +197,19 @@ describe('line ending selector', () => {
 
       describe('when the text editor does not have focus', () => {
         it('opens the line ending selector modal for the active text editor', () => {
-          // TODO
+          atom.workspace.getLeftDock().activate()
+          const item = atom.workspace.getActivePaneItem()
+          expect(item instanceof TextEditor).toBe(false)
+
+          lineEndingTile.element.dispatchEvent(new MouseEvent('click', {}))
+          lineEndingModal = atom.workspace.getModalPanels()[0]
+          lineEndingSelector = lineEndingModal.getItem()
+
+          expect(lineEndingModal.isVisible()).toBe(true)
+          expect(lineEndingSelector.element.contains(document.activeElement)).toBe(true)
+          let listItems = lineEndingSelector.element.querySelectorAll('li')
+          expect(listItems[0].textContent).toBe('LF')
+          expect(listItems[1].textContent).toBe('CRLF')
         })
       })
 

--- a/spec/line-ending-selector-spec.js
+++ b/spec/line-ending-selector-spec.js
@@ -212,7 +212,7 @@ describe('line ending selector', () => {
       })
     })
 
-    describe('clicking out of a text editor', () => {
+    describe('closing the last text editor', () => {
       it('displays no line ending in the status bar', () => {
         waitsForPromise(() => {
           return atom.workspace.open('unix-endings.md').then(() => {


### PR DESCRIPTION
### Description of the Change

This pull request adds a test for the bug fixed in 2ff4ee3f83.

Normally, I prefer to add the test first and then fix the bug second. We were in a bit of a time crunch to get https://github.com/atom/line-ending-selector/pull/46 shipped, so I committed the bug fix in that PR, and I'm following up with this PR to add the corresponding test.

It's probably easier to review this PR's individual commits than it is to review the consolidated diff. For example, f5ea7d0574f32b0df1932b7e047e87be96844ff9 refactors the existing tests to make room for adding a new test related to the bug. Then, ed3da092e0d0e57108cf5000435b84a1e3c75945 adds the new test related to the bug.

### Alternate Designs

N/A

### Benefits

We're less likely to accidentally re-introduce the bug fixed in 2ff4ee3f83.

### Possible Drawbacks

N/A

### Applicable Issues

https://github.com/atom/line-ending-selector/pull/46
