### PR TITLE
Remove obsolete conditionals re: active text editor APIs

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -81,11 +81,11 @@ export function consumeStatusBar (statusBar) {
     })
   }, 0)
 
-  disposables.add(atom.workspace.observeActiveTextEditor((item) => {
+  disposables.add(atom.workspace.observeActiveTextEditor((editor) => {
     if (currentBufferDisposable) currentBufferDisposable.dispose()
 
-    if (item && item.getBuffer) {
-      let buffer = item.getBuffer()
+    if (editor && editor.getBuffer) {
+      let buffer = editor.getBuffer()
       updateTile(buffer)
       currentBufferDisposable = buffer.onDidChange(({oldText, newText}) => {
         if (!statusBarItem.hasLineEnding('\n')) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -24,12 +24,7 @@ export function activate () {
           items: [{name: 'LF', value: '\n'}, {name: 'CRLF', value: '\r\n'}],
           filterKeyForItem: (lineEnding) => lineEnding.name,
           didConfirmSelection: (lineEnding) => {
-            // TODO[v1.19]: Remove conditional once atom.workspace.getActiveTextEditor ships in Atom v1.19
-            if (atom.workspace.getActiveTextEditor) {
-              setLineEnding(atom.workspace.getActiveTextEditor(), lineEnding.value)
-            } else {
-              setLineEnding(atom.workspace.getActivePaneItem(), lineEnding.value)
-            }
+            setLineEnding(atom.workspace.getActiveTextEditor(), lineEnding.value)
             modalPanel.hide()
           },
           didCancelSelection: () => {
@@ -134,15 +129,7 @@ export function consumeStatusBar (statusBar) {
   }))
 
   statusBarItem.onClick(() => {
-    let editor
-
-    // TODO[v1.19]: Remove conditional once atom.workspace.getActiveTextEditor ships in Atom v1.19
-    if (atom.workspace.getActiveTextEditor) {
-      editor = atom.workspace.getActiveTextEditor()
-    } else {
-      editor = atom.workspace.getActivePaneItem()
-    }
-
+    const editor = atom.workspace.getActiveTextEditor()
     atom.commands.dispatch(
       atom.views.getView(editor),
       'line-ending-selector:show'

--- a/lib/main.js
+++ b/lib/main.js
@@ -117,12 +117,7 @@ export function consumeStatusBar (statusBar) {
     disposables.add(tooltipDisposable)
   }
 
-  // TODO[v1.19]: Remove conditional once atom.workspace.observeActiveTextEditor ships in Atom v1.19
-  if (atom.workspace.observeActiveTextEditor) {
-    disposables.add(atom.workspace.observeActiveTextEditor(observeActiveItem))
-  } else {
-    disposables.add(atom.workspace.observeActivePaneItem(observeActiveItem))
-  }
+  disposables.add(atom.workspace.observeActiveTextEditor(observeActiveItem))
 
   disposables.add(new Disposable(() => {
     if (currentBufferDisposable) currentBufferDisposable.dispose()

--- a/lib/main.js
+++ b/lib/main.js
@@ -81,7 +81,7 @@ export function consumeStatusBar (statusBar) {
     })
   }, 0)
 
-  const observeActiveItem = function (item) {
+  disposables.add(atom.workspace.observeActiveTextEditor((item) => {
     if (currentBufferDisposable) currentBufferDisposable.dispose()
 
     if (item && item.getBuffer) {
@@ -115,9 +115,7 @@ export function consumeStatusBar (statusBar) {
       }
     })
     disposables.add(tooltipDisposable)
-  }
-
-  disposables.add(atom.workspace.observeActiveTextEditor(observeActiveItem))
+  }))
 
   disposables.add(new Disposable(() => {
     if (currentBufferDisposable) currentBufferDisposable.dispose()


### PR DESCRIPTION
This PR removes the conditional logic (originally introduced in https://github.com/atom/line-ending-selector/pull/46) that tested for the existence of `atom.workspace.getActiveTextEditor` and `atom.workspace.observeActiveTextEditor`. Now that Atom 1.19 has been released, we can safely expect these methods to to be available:

- [`atom.workspace.getActiveTextEditor`](https://github.com/atom/atom/blob/v1.19.0/src/workspace.js#L1326-L1333)
- [`atom.workspace.observeActiveTextEditor`](https://github.com/atom/atom/blob/v1.19.0/src/workspace.js#L689-L702)
