### PR TITLE
Prevent LFRegExp from matching on "\r\n"

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -7,7 +7,7 @@ import StatusBarItem from './status-bar-item'
 import helpers from './helpers'
 
 const LineEndingRegExp = /\r\n|\n/g
-const LFRegExp = /(^|[^\r])\n/g
+const LFRegExp = /(\A|[^\r])\n/g
 const CRLFRegExp = /\r\n/g
 
 let disposables = null


### PR DESCRIPTION
Now that superstring is using "any" line ending mode, the `^` in LFRegExp was matching between "\r\n" sequences, causing all CRLF files to be detected as "Mixed". Use `\A` to anchor specifically to the beginning of the buffer instead.