### PR TITLE
Fix flaky test re: "changes the line endings in the buffer" 🤞

### DIFF
--- a/spec/line-ending-selector-spec.js
+++ b/spec/line-ending-selector-spec.js
@@ -223,19 +223,21 @@ describe('line ending selector', () => {
           lineEndingModal = atom.workspace.getModalPanels()[0]
           lineEndingSelector = lineEndingModal.getItem()
 
-          lineEndingSelector.refs.queryEditor.setText('CR')
-          lineEndingSelector.confirmSelection()
-          expect(lineEndingModal.isVisible()).toBe(false)
-
-          waitsFor((done) => {
+          const lineEndingChangedPromise = new Promise(resolve => {
             lineEndingTile.onDidChange(() => {
               expect(lineEndingTile.element.textContent).toBe('CRLF')
               const editor = atom.workspace.getActiveTextEditor()
               expect(editor.getText()).toBe('Hello\r\nGoodbye\r\nUnix\r\n')
               expect(editor.getBuffer().getPreferredLineEnding()).toBe('\r\n')
-              done()
+              resolve()
             })
           })
+
+          lineEndingSelector.refs.queryEditor.setText('CR')
+          lineEndingSelector.confirmSelection()
+          expect(lineEndingModal.isVisible()).toBe(false)
+
+          waitsForPromise(() => lineEndingChangedPromise)
         })
       })
 


### PR DESCRIPTION
We've seen a few instances of the CI failure described in https://github.com/atom/atom/issues/17326, but I haven't been able to reproduce it locally. :sweat: However, I've reviewed the [first test referenced in that CI failure](https://github.com/atom/line-ending-selector/blob/cbcfd1bbcc3d48f039727d23d25bcc7d5852e7fa/spec/line-ending-selector-spec.js#L220-L240), and I think I see the potential cause of the failure.

Currently, the test [changes the line ending for a file](https://github.com/atom/line-ending-selector/blob/cbcfd1bbcc3d48f039727d23d25bcc7d5852e7fa/spec/line-ending-selector-spec.js#L226-L227), _then_ [registers a change observer](https://github.com/atom/line-ending-selector/blob/cbcfd1bbcc3d48f039727d23d25bcc7d5852e7fa/spec/line-ending-selector-spec.js#L231), and then [waits for the change observer to be called](https://github.com/atom/line-ending-selector/blob/cbcfd1bbcc3d48f039727d23d25bcc7d5852e7fa/spec/line-ending-selector-spec.js#L230). Since we aren't registering the change observer until after we change the line endings, I suspect that could lead to us waiting forever for our change observer to get called, thus leading to a failure like the timeout that we're seeing.

To make sure the observer gets called when the line endings change, this pull request registers the observer before changing the line endings, then changes the line endings, and then waits until the observer has been called.
