### PR TITLE
Update README to deprecate repository and redirect readers to atom/atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### This package is now a part of the [core Atom repository](https://github.com/atom/atom/tree/master/packages/line-ending-selector). Please direct all issues and pull requests there in the future!
+
+---
+
 # Line Ending Selector package
 [![OS X Build Status](https://travis-ci.org/atom/line-ending-selector.svg?branch=master)](https://travis-ci.org/atom/line-ending-selector) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/b3743n9ojomlpn1g/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/line-ending-selector/branch/master) [![Dependency Status](https://david-dm.org/atom/line-ending-selector.svg)](https://david-dm.org/atom/line-ending-selector)
 


### PR DESCRIPTION
With the changes in https://github.com/atom/atom/pull/18239, the line-ending-selector package is now a part of the core Atom repository. This pull request updates the README to reflect that fact. We'll be archiving this repository shortly.

/cc https://github.com/atom/atom/issues/17847
